### PR TITLE
Suggest Splink settings with faster runtimes (not compromising accuracy)

### DIFF
--- a/packages/splink_runtime.py
+++ b/packages/splink_runtime.py
@@ -6,9 +6,9 @@ import pandas as pd
 from  pathlib import Path
 import os
 
-# logs = ["splink.estimate_u", "splink.expectation_maximisation", "splink.settings", "splink.em_training_session", "comparison_level"]
-# for log in logs:
-#     logging.getLogger(log).setLevel(logging.ERROR)
+logs = ["splink.estimate_u", "splink.expectation_maximisation", "splink.settings", "splink.em_training_session", "comparison_level"]
+for log in logs:
+    logging.getLogger(log).setLevel(logging.ERROR)
 
 
 root_folder = Path(__file__).parents[1]
@@ -43,7 +43,7 @@ settings = {
 }
 
 x = [2000,4000,6000,8000,10000,12000,14000,16000,18000,20000,22000,24000,26000,28000,30000,32000,34000,36000,38000,40000]
-x = [40000]
+
 for size in x:
 
     dfA = pd.read_csv(os.path.join(df_folder, str(size) + "_dfA.csv"), names = columns)
@@ -90,7 +90,7 @@ for size in x:
             "\n"
         )
 
-# A few diagnostics
+# A few diagnostics to take a look at the quality of the model:
 # linker.match_weights_chart()
 
 # false_positives = linker.prediction_errors_from_labels_column("id", include_false_negatives=False, include_false_positives=True).as_pandas_dataframe(limit=10)

--- a/packages/splink_runtime.py
+++ b/packages/splink_runtime.py
@@ -43,7 +43,6 @@ settings = {
 }
 
 x = [2000,4000,6000,8000,10000,12000,14000,16000,18000,20000,22000,24000,26000,28000,30000,32000,34000,36000,38000,40000]
-
 for size in x:
 
     dfA = pd.read_csv(os.path.join(df_folder, str(size) + "_dfA.csv"), names = columns)
@@ -68,29 +67,30 @@ for size in x:
 
     time_end = time.time()
 
-    df_predict = predict.as_pandas_dataframe()
-    pairs_data = linker.cumulative_comparisons_from_blocking_rules_records(blocking_rules_for_prediction)
-    pairs = sum([r['row_count'] for r in pairs_data])
+    # df_predict = predict.as_pandas_dataframe()
+    # pairs_data = linker.cumulative_comparisons_from_blocking_rules_records(blocking_rules_for_prediction)
+    # pairs = sum([r['row_count'] for r in pairs_data])
 
-    false_positive = len(df_predict.loc[df_predict["id_l"] != df_predict["id_r"]])
-    true_positive = len(df_predict.loc[df_predict["id_l"] == df_predict["id_r"]])
-    false_negative = round(size / 2) - true_positive
+    # false_positive = len(df_predict.loc[df_predict["id_l"] != df_predict["id_r"]])
+    # true_positive = len(df_predict.loc[df_predict["id_l"] == df_predict["id_r"]])
+    # false_negative = round(size / 2) - true_positive
 
-    precision = true_positive / (true_positive + false_positive)
-    recall = true_positive / (true_positive + false_negative)
+    # precision = true_positive / (true_positive + false_positive)
+    # recall = true_positive / (true_positive + false_negative)
 
-    with open(os.path.join(results_folder, "splink_outputs_complex_model.txt"), "a") as f:
-        f.writelines(
-            "Sample Size: " + str(size) +
-            "|Links Predicted: " + str(len(df_predict)) +
-            "|Time Taken: " + str(round((time_end - time_start),2)) +
-            "|Precision: " + str(precision) +
-            "|Recall: " + str(recall) +
-            "|Linkage Pairs: " + str(pairs) +
-            "\n"
-        )
+    # with open(os.path.join(results_folder, "splink_outputs_complex_model.txt"), "a") as f:
+    #     f.writelines(
+    #         "Sample Size: " + str(size) +
+    #         "|Links Predicted: " + str(len(df_predict)) +
+    #         "|Time Taken: " + str(round((time_end - time_start),2)) +
+    #         "|Precision: " + str(precision) +
+    #         "|Recall: " + str(recall) +
+    #         "|Linkage Pairs: " + str(pairs) +
+    #         "\n"
+    #     )
 
 # A few diagnostics to take a look at the quality of the model:
+# linker.roc_chart_from_labels_column("id")
 # linker.match_weights_chart()
 
 # false_positives = linker.prediction_errors_from_labels_column("id", include_false_negatives=False, include_false_positives=True).as_pandas_dataframe(limit=10)

--- a/packages/splink_runtime_faster_less_complex.py
+++ b/packages/splink_runtime_faster_less_complex.py
@@ -29,11 +29,11 @@ settings = {
     "link_type": "link_only",
     "unique_id_column_name": "id",
     "comparisons": [
-        cl.jaro_winkler_at_thresholds(col_name="first_name", distance_threshold_or_thresholds=0.9, term_frequency_adjustments=True),
-        cl.jaro_winkler_at_thresholds(col_name="last_name", distance_threshold_or_thresholds=0.9, term_frequency_adjustments=True),
-        cl.jaro_winkler_at_thresholds(col_name="middle_name", distance_threshold_or_thresholds=0.9, term_frequency_adjustments=True),
-        cl.levenshtein_at_thresholds(col_name="res_street_address", distance_threshold_or_thresholds=[1,3,5], term_frequency_adjustments=False),
-        cl.levenshtein_at_thresholds(col_name="birth_year", distance_threshold_or_thresholds=1, term_frequency_adjustments=True)
+        cl.exact_match(col_name="first_name",  term_frequency_adjustments=False),
+        cl.exact_match(col_name="last_name",  term_frequency_adjustments=False),
+        cl.exact_match(col_name="middle_name",  term_frequency_adjustments=False),
+        cl.exact_match(col_name="res_street_address", term_frequency_adjustments=False),
+        cl.exact_match(col_name="birth_year", term_frequency_adjustments=False)
     ],
     #Blocking used here
     "blocking_rules_to_generate_predictions": blocking_rules_for_prediction,
@@ -79,7 +79,7 @@ for size in x:
     precision = true_positive / (true_positive + false_positive)
     recall = true_positive / (true_positive + false_negative)
 
-    with open(os.path.join(results_folder, "splink_outputs_complex_model.txt"), "a") as f:
+    with open(os.path.join(results_folder, "splink_outputs_simple_model.txt"), "a") as f:
         f.writelines(
             "Sample Size: " + str(size) +
             "|Links Predicted: " + str(len(df_predict)) +

--- a/packages/splink_runtime_faster_less_complex.py
+++ b/packages/splink_runtime_faster_less_complex.py
@@ -63,7 +63,7 @@ for size in x:
 
     for i in training:
         linker.estimate_parameters_using_expectation_maximisation(i)
-    predict = linker.predict(0.85) #Has None as a dafault value, thus 0.95 was needed for any analysis
+     predict = linker.predict(0.5) # This should be 0.5 for your accuracy derivations to be correct
 
     time_end = time.time()
 

--- a/packages/splink_runtime_faster_less_complex.py
+++ b/packages/splink_runtime_faster_less_complex.py
@@ -43,7 +43,6 @@ settings = {
 }
 
 x = [2000,4000,6000,8000,10000,12000,14000,16000,18000,20000,22000,24000,26000,28000,30000,32000,34000,36000,38000,40000]
-x = [40000]
 for size in x:
 
     dfA = pd.read_csv(os.path.join(df_folder, str(size) + "_dfA.csv"), names = columns)
@@ -92,6 +91,7 @@ for size in x:
 
 # A few diagnostics
 # linker.match_weights_chart()
+linker.roc_chart_from_labels_column("id")
 
 # false_positives = linker.prediction_errors_from_labels_column("id", include_false_negatives=False, include_false_positives=True).as_pandas_dataframe(limit=10)
 # false_negatives = linker.prediction_errors_from_labels_column("id", include_false_negatives=True, include_false_positives=False).as_pandas_dataframe(limit=10)

--- a/profile_data_using_splink.py
+++ b/profile_data_using_splink.py
@@ -1,0 +1,51 @@
+from splink.duckdb.duckdb_linker import DuckDBLinker
+import splink.duckdb.duckdb_comparison_library as cl
+import logging
+import time
+import pandas as pd
+from  pathlib import Path
+import os
+
+logs = ["splink.estimate_u", "splink.expectation_maximisation", "splink.settings", "splink.em_training_session", "comparison_level"]
+for log in logs:
+    logging.getLogger(log).setLevel(logging.ERROR)
+
+
+root_folder = Path(__file__).parents[0]
+
+df_folder = root_folder / "sample_df"
+results_folder = root_folder / "results"
+
+columns = ["id", "first_name", "middle_name", "last_name", "res_street_address", "birth_year", "zip_code"]
+
+settings = {
+    "link_type": "link_only",
+    "unique_id_column_name": "id",
+
+}
+
+
+size = 40000
+
+
+dfA = pd.read_csv(os.path.join(df_folder, str(size) + "_dfA.csv"), names = columns)
+dfB = pd.read_csv(os.path.join(df_folder, str(size) + "_dfB.csv"), names = columns)
+
+linker = DuckDBLinker([dfA, dfB], settings)
+linker.profile_columns(list(dfA.columns))
+
+linker.profile_columns(["first_name||middle_name"])
+linker.missingness_chart()
+
+
+# Looking at cardinality blocking on res_street_address and
+
+linker.count_num_comparisons_from_blocking_rule("l.first_name = r.first_name and l.last_name = r.last_name")
+linker.count_num_comparisons_from_blocking_rule("l.first_name = r.first_name and l.middle_name = r.middle_name")
+linker.count_num_comparisons_from_blocking_rule("l.res_street_address = r.res_street_address")
+linker.count_num_comparisons_from_blocking_rule("l.birth_year = r.birth_year and l.middle_name = r.middle_name")
+linker.count_num_comparisons_from_blocking_rule("l.birth_year = r.birth_year and l.last_name = r.last_name")
+
+
+# This takes ages to compute because there are over a billion! = 1,109,496,951
+linker.count_num_comparisons_from_blocking_rule("l.zip_code = r.zip_code")


### PR DESCRIPTION
These are just some suggestion there's no need to actually merge. I just thought this was the easiest way to make it obvious what I was suggesting

I've proposed two different models, one simple (fast runtime) and another more complex (more precise)

Note that these models shouldn't sacrifice accuracy, I've just used improved the settings to make them run faster.

Against the size = 40,000 dataset, the results are as follows (headline:  11 seconds for complex model, 2 seconds for simple model)

More complex model:
```
Sample Size: 40000|Links Predicted: 25097|Time Taken: 11.8|Precision: 0.7763876160497271|Recall: 0.97425|Linkage Pairs: 161944
```

Simpler model:
```
Sample Size: 40000|Links Predicted: 23139|Time Taken: 1.92|Precision: 0.8349539738104499|Recall: 0.966|Linkage Pairs: 161944
```

From a runtime point of view the key changes are:
```
blocking_rules_for_prediction = [
        "l.first_name = r.first_name and l.last_name = r.last_name",
        "l.first_name = r.first_name and l.middle_name = r.middle_name",
        "l.res_street_address = r.res_street_address",
        "l.birth_year = r.birth_year and l.middle_name = r.middle_name",
        "l.birth_year = r.birth_year and l.last_name = r.last_name"
]
```

and 

```
training = [
        "l.first_name = r.first_name and l.last_name = r.last_name",
        "l.res_street_address = r.res_street_address"
    ]
```

From an accuracy point of view, I changed the settings to use jaro_winkler which is more suitable for names.


You'll also see I wrote `profile_data_using_splink.py`, which produces the evidence I needed to decide on the blocking rules/new model specs.